### PR TITLE
style/darkmode restyle for readability

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -37,3 +37,7 @@ icon_file = "youtube.svg"
 url = "/index.xml"
 alt_text = "The bespinian blog RSS feed"
 icon_file = "rss.svg"
+
+[markup]
+    [markup.highlight]
+        style = "github-dark"

--- a/static/custom.css
+++ b/static/custom.css
@@ -74,10 +74,11 @@
   --grey-1: #606060;
   --grey-2: #404040;
   --grey-3: #202020;
-  --grey-4: #181818;
+  --grey-4: #6e768166;
   --white: #fff;
-  --blue: #3273dc --shadow-color: rgba(0, 0, 0, 0.2);
-  --code-color: #3273dc;
+  --blue: #3273dc;
+  --shadow-color: rgba(0, 0, 0, 0.2);
+  --code-color: #f0f0f0;
   --code-filter: contrast(0.4) brightness(0.9);
 }
 

--- a/static/custom.css
+++ b/static/custom.css
@@ -76,8 +76,14 @@
   --grey-3: #202020;
   --grey-4: #181818;
   --white: #fff;
-  --shadow-color: rgba(0, 0, 0, 0.2);
+  --blue: #3273dc --shadow-color: rgba(0, 0, 0, 0.2);
+  --code-color: #3273dc;
   --code-filter: contrast(0.4) brightness(0.9);
+}
+
+a {
+  color: #3273dc;
+  text-decoration: none;
 }
 
 h1,

--- a/static/custom.css
+++ b/static/custom.css
@@ -70,7 +70,7 @@
   --default-color: #f0f0f0;
   --background-color: #000;
   --default-shade: #ffffff;
-  --default-tint: #555;
+  --default-tint: #f0f0f0;
   --grey-1: #606060;
   --grey-2: #404040;
   --grey-3: #202020;

--- a/static/custom.css
+++ b/static/custom.css
@@ -79,7 +79,7 @@
   --blue: #3273dc;
   --shadow-color: rgba(0, 0, 0, 0.2);
   --code-color: #f0f0f0;
-  --code-filter: contrast(0.4) brightness(0.9);
+  --code-filter: contrast(1) brightness(1);
 }
 
 a {
@@ -97,8 +97,9 @@ h6,
   font-family: Lato, "Helvetica Neue", "Segoe UI", Helvetica, Arial, sans-serif;
   font-weight: 700;
 }
+
 .highlight {
-  background-color: #272822;
+  background: #0d1117;
 }
 
 .bespinian-social-nav-container {

--- a/static/custom.css
+++ b/static/custom.css
@@ -66,6 +66,20 @@
     U+FEFF, U+FFFD;
 }
 
+:root:not(.light) {
+  --default-color: #f0f0f0;
+  --background-color: #000;
+  --default-shade: #ffffff;
+  --default-tint: #555;
+  --grey-1: #606060;
+  --grey-2: #404040;
+  --grey-3: #202020;
+  --grey-4: #181818;
+  --white: #fff;
+  --shadow-color: rgba(0, 0, 0, 0.2);
+  --code-filter: contrast(0.4) brightness(0.9);
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
- Increase contrast of post content and titles 
- Make links bespinian blue 
- Set inline code highlighting to match GitHub style 
- Increase contrast for names and dates in blog posts
- Change syntax highlighting to GitHub dark with no contrast dimming

Old:
![image](https://github.com/bespinian/blog/assets/37380474/903612f3-8bb2-41ba-a4cd-207be6b527a8)


New:
![image](https://github.com/bespinian/blog/assets/37380474/f4cfe907-1d6d-4937-9385-e80f0ffb772c)

